### PR TITLE
Bug/artemis queue is multicast

### DIFF
--- a/artcoded/src/main/java/tech/artcoded/websitev2/event/EventAuditLog.java
+++ b/artcoded/src/main/java/tech/artcoded/websitev2/event/EventAuditLog.java
@@ -17,7 +17,7 @@ public class EventAuditLog extends RouteBuilder {
   @Override
   public void configure() throws Exception {
     log.warn("Event audit log consumer is enabled.");
-    fromF("jms:topic:%s", topicToPublish)
+    fromF("%s", topicToPublish)
       .routeId("EventAuditLog#consume")
       .log(LoggingLevel.DEBUG, "event of type '${headers.EventType}' received: ${body}");
   }

--- a/artcoded/src/main/java/tech/artcoded/websitev2/event/EventRouteBuilder.java
+++ b/artcoded/src/main/java/tech/artcoded/websitev2/event/EventRouteBuilder.java
@@ -21,6 +21,6 @@ public class EventRouteBuilder extends RouteBuilder {
       .filter(body().isInstanceOf(IEvent.class))
       .setHeader("EventType", simple("${body.eventName}"))
       .marshal().json(JsonLibrary.Jackson)
-      .to(ExchangePattern.InOnly, "jms:topic:" + topicToPublish);
+      .to(ExchangePattern.InOnly, topicToPublish);
   }
 }

--- a/artcoded/src/main/resources/config/artemis.yml
+++ b/artcoded/src/main/resources/config/artemis.yml
@@ -9,5 +9,5 @@ spring:
 
 application:
   events:
-    topicPublish: ${EVENT_TOPIC_PUBLISH:backend-event}
+    topicPublish: jms:${EVENT_TOPIC_PUBLISH:backend-event}
     consumerEnabled: ${EVENT_TOPIC_PUBLISH_CONSUMER_ENABLED:true}


### PR DESCRIPTION
## Description

When creating a queue, with the old configuration it was in multicast. With the new configuration it is now anycast. If nobody listens the queue, the messages are then held until someone consume them.

Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

There wasn't real test except trying manually the app and verifying the queue in Artemis's console manager

- [x] Creating event without any consumer
- [x] Connect consumer after event creation

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: VSCode
* SDK: .NET 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
